### PR TITLE
fix: remove link to blog.johnnyreilly.com google analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,13 +52,6 @@ const config = {
         },
       };
     },
-    [
-      "@docusaurus/plugin-google-gtag",
-      {
-        trackingID: "G-226F0LR9KE",
-        anonymizeIP: true,
-      },
-    ],
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */


### PR DESCRIPTION
## Description

I'd like you to stop sending traffic to my Google Analytics property!

## Linked Issues
If these changes close one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

https://github.com/facebook/docusaurus/pull/8313

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
